### PR TITLE
Add ingress rule for concourse workers

### DIFF
--- a/concourse.tf
+++ b/concourse.tf
@@ -84,6 +84,13 @@ resource "aws_security_group" "concourse_web_worker_sg" {
   }
 
   ingress {
+    from_port   = 2222
+    to_port     = 2222
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  
+  ingress {
     from_port   = 8080
     to_port     = 8080
     protocol    = "tcp"


### PR DESCRIPTION
The terraform config is missing an ingress rule for the web / worker security group allowing communication on port 2222 - this means that workers cannot register. This commit adds the necessary security group rule to fix this :)